### PR TITLE
Add React dashboard scaffold

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pi Dashboard</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@shadcn/ui": "^0.4.0",
+    "recharts": "^2.8.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/dashboard/postcss.config.js
+++ b/dashboard/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { InfoCard } from './components/InfoCard';
+import { ChartCard } from './components/ChartCard';
+import { trainingStats, dietData, activityData, weatherData } from './data';
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, BarChart, Bar } from 'recharts';
+
+const App: React.FC = () => {
+  return (
+    <div className="container mx-auto p-4 space-y-6">
+      <h1 className="text-3xl font-bold mb-4">Pi Dashboard</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <InfoCard title="Steps" value={trainingStats.steps} />
+        <InfoCard title="Calories Burned" value={trainingStats.calories} />
+        <InfoCard title="Workout Duration" value={`${trainingStats.durationMinutes} min`} />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <ChartCard title="Diet (Calories Last 7 Days)">
+          <LineChart width={400} height={200} data={dietData} className="w-full">
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="calories" stroke="#8884d8" strokeWidth={2} />
+          </LineChart>
+        </ChartCard>
+
+        <ChartCard title="Daily Activity">
+          <BarChart width={400} height={200} data={activityData} className="w-full">
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="hour" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="activeHours" fill="#82ca9d" />
+          </BarChart>
+        </ChartCard>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {weatherData.map((w) => (
+          <InfoCard key={w.city} title={w.city} value={`${w.temperature}°C - ${w.condition}`} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/dashboard/src/components/ChartCard.tsx
+++ b/dashboard/src/components/ChartCard.tsx
@@ -1,0 +1,16 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@shadcn/ui";
+import React from "react";
+
+interface Props {
+  title: string;
+  children: React.ReactNode;
+}
+
+export const ChartCard: React.FC<Props> = ({ title, children }) => (
+  <Card className="rounded-lg shadow-sm p-4">
+    <CardHeader>
+      <CardTitle className="text-sm text-gray-500">{title}</CardTitle>
+    </CardHeader>
+    <CardContent>{children}</CardContent>
+  </Card>
+);

--- a/dashboard/src/components/InfoCard.tsx
+++ b/dashboard/src/components/InfoCard.tsx
@@ -1,0 +1,18 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@shadcn/ui";
+import React from "react";
+
+interface Props {
+  title: string;
+  value: string | number;
+}
+
+export const InfoCard: React.FC<Props> = ({ title, value }) => (
+  <Card className="rounded-lg shadow-sm p-4">
+    <CardHeader>
+      <CardTitle className="text-sm text-gray-500">{title}</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <p className="text-2xl font-semibold">{value}</p>
+    </CardContent>
+  </Card>
+);

--- a/dashboard/src/data.ts
+++ b/dashboard/src/data.ts
@@ -1,0 +1,32 @@
+import { TrainingStats, DietDataPoint, ActivityDataPoint, WeatherInfo } from './types';
+
+export const trainingStats: TrainingStats = {
+  steps: 12000,
+  calories: 500,
+  durationMinutes: 75,
+};
+
+export const dietData: DietDataPoint[] = [
+  { date: 'Day 1', calories: 2200 },
+  { date: 'Day 2', calories: 2100 },
+  { date: 'Day 3', calories: 2000 },
+  { date: 'Day 4', calories: 2300 },
+  { date: 'Day 5', calories: 1950 },
+  { date: 'Day 6', calories: 2150 },
+  { date: 'Day 7', calories: 2050 },
+];
+
+export const activityData: ActivityDataPoint[] = [
+  { hour: '6 AM', activeHours: 1 },
+  { hour: '9 AM', activeHours: 2 },
+  { hour: '12 PM', activeHours: 1 },
+  { hour: '3 PM', activeHours: 2 },
+  { hour: '6 PM', activeHours: 3 },
+  { hour: '9 PM', activeHours: 1 },
+];
+
+export const weatherData: WeatherInfo[] = [
+  { city: 'Córdoba', temperature: 22, condition: 'Sunny' },
+  { city: 'Lucena', temperature: 21, condition: 'Partly Cloudy' },
+  { city: 'Savigliano', temperature: 18, condition: 'Rainy' },
+];

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -1,0 +1,21 @@
+export interface TrainingStats {
+  steps: number;
+  calories: number;
+  durationMinutes: number;
+}
+
+export interface DietDataPoint {
+  date: string;
+  calories: number;
+}
+
+export interface ActivityDataPoint {
+  hour: string;
+  activeHours: number;
+}
+
+export interface WeatherInfo {
+  city: string;
+  temperature: number;
+  condition: string;
+}

--- a/dashboard/tailwind.config.js
+++ b/dashboard/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["DOM", "DOM.Iterable", "ES2017"],
+    "types": ["vite/client"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a React dashboard using Tailwind and ShadCN UI
- add TypeScript config and Vite setup
- implement InfoCard and ChartCard components
- mock training, diet, activity and weather data
- create App layout with Recharts

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_b_683c2f6da7188321b4d4c7830191a8ff